### PR TITLE
Tani develop candidate 02 24 2019 utf8mb4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,13 @@ RUN apt-get update \
        mysql-client \
     && rm -fr /var/lib/apt/lists/*
 
+# Warning - when I tried to include XML::Simple near the start of the first "cpanm install" line, there was an error:
+#       Building and testing XMLRPC-Lite-0.717 ... ! Installing XMLRPC::Lite failed. See /root/.cpanm/work/1551887935.125/build.log for details. Retry with --force to force install it.
+# so it was put into a second "cpanm install" line.
+
 RUN curl -Lk https://cpanmin.us | perl - App::cpanminus \
     && cpanm install XML::Parser::EasyTree Iterator Iterator::Util Pod::WSDL Array::Utils HTML::Template XMLRPC::Lite Mail::Sender Email::Sender::Simple Data::Dump Statistics::R::IO \
+    && cpanm install XML::Simple \
     && rm -fr ./cpanm /root/.cpanm /tmp/*
 
 RUN mkdir -p $APP_ROOT/courses $APP_ROOT/libraries $APP_ROOT/webwork2

--- a/bin/OPL-update
+++ b/bin/OPL-update
@@ -92,11 +92,11 @@ my $dbh = DBI->connect(
         {
                 PrintError => 0,
                 RaiseError => 1,
-		mysql_enable_utf8 => 1,
+		mysql_enable_utf8mb4 => 1,
         },
 );
 
-$dbh->prepare("SET NAMES 'utf8'")->execute();
+$dbh->prepare("SET NAMES 'utf8mb4'")->execute();
 
 my $libraryRoot = $ce->{problemLibrary}->{root};
 $libraryRoot =~ s|/+$||;
@@ -135,13 +135,13 @@ if($libraryVersion eq '2.5') {
 @create_tables = (
 [$tables{dbsubject}, '
 	DBsubject_id int(15) NOT NULL auto_increment,
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	KEY DBsubject (name),
 	PRIMARY KEY (DBsubject_id)
 '],
 [$tables{dbchapter}, '
 	DBchapter_id int(15) NOT NULL auto_increment,
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	DBsubject_id int(15) DEFAULT 0 NOT NULL,
 	KEY DBchapter (name),
 	KEY (DBsubject_id),
@@ -149,7 +149,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{dbsection}, '
 	DBsection_id int(15) NOT NULL auto_increment,
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	DBchapter_id int(15) DEFAULT 0 NOT NULL,
 	KEY DBsection (name),
 	KEY (DBchapter_id),
@@ -166,7 +166,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{path}, '
 	path_id int(15) NOT NULL auto_increment,
-	path varchar(255) NOT NULL,
+	path varchar(245) NOT NULL,
 	machine varchar(255),
 	user varchar(255),
 	KEY (path),
@@ -212,7 +212,7 @@ if($libraryVersion eq '2.5') {
 	chapter_id int (15) NOT NULL auto_increment,
 	textbook_id int (15),
 	number int(3),
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	page int(4),
 	KEY (textbook_id, name),
 	KEY (number),
@@ -222,7 +222,7 @@ if($libraryVersion eq '2.5') {
 	section_id int(15) NOT NULL auto_increment,
 	chapter_id int (15),
 	number int(3),
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	page int(4),
 	KEY (chapter_id, name),
 	KEY (number),
@@ -239,7 +239,7 @@ if($libraryVersion eq '2.5') {
 '],
 [$tables{morelt}, '
 	morelt_id int(15) NOT NULL auto_increment,
-	name varchar(255) NOT NULL,
+	name varchar(245) NOT NULL,
 	DBsection_id int(15),
 	leader int(15), # pgfile_id of the MLT leader
 	KEY (name),

--- a/bin/update-OPL-statistics
+++ b/bin/update-OPL-statistics
@@ -79,9 +79,9 @@ CREATE TABLE IF NOT EXISTS `OPL_problem_user` (
   `attempted` int(11) DEFAULT NULL,
   `num_correct` int(11) DEFAULT NULL,
   `num_incorrect` int(11) DEFAULT NULL,
-  UNIQUE KEY `unique_key_idx` (`course_id`(100),`user_id`(100),`set_id`(100),`due_date`,`problem_id`),
-  KEY `source_file_idx` (`source_file`(255)))
-  CHARACTER SET ascii
+  UNIQUE KEY `unique_key_idx` (`course_id`(80),`user_id`(80),`set_id`(80),`due_date`,`problem_id`),
+  KEY `source_file_idx` (`source_file`(245)))
+  CHARACTER SET utf8mb4
 EOS
 
 $dbh->do(<<EOS);
@@ -90,12 +90,12 @@ EOS
 
 $dbh->do(<<EOS);
 CREATE TABLE `OPL_local_statistics` (
-  `source_file` varchar(255) NOT NULL,
+  `source_file` varchar(245) NOT NULL,
   `students_attempted` int(11) DEFAULT NULL,
   `average_attempts` float DEFAULT NULL,
   `average_status` float DEFAULT NULL,
-  PRIMARY KEY (`source_file`(255))
-)
+  PRIMARY KEY (`source_file`(245))
+)  ENGINE=MyISAM
 EOS
 
 $dbh->commit();

--- a/docker-compose.yml.specialUTF8MB4-db-storage
+++ b/docker-compose.yml.specialUTF8MB4-db-storage
@@ -1,9 +1,14 @@
 version: '2'
 services:
-  db:
+  # We have renamed the database service from "db" to "dbMB4",
+  # changed the name of the data volume to "mysqlMB4" and set
+  # environment variables to use the "dbMB4" server. All this was needed
+  # ONLY to allow leaving a version of the "db" container which does not
+  # use utf8mb4 available until the UTF8MB4 changes become mainstream.
+  dbMB4:
     image: mariadb:10.1
     volumes:
-      - mysql:/var/lib/mysql
+      - mysqlMB4:/var/lib/mysql
       # Set up UTF8MB4 in config file for the container.
       # Needs to be done BEFORE the database is created.
       - "./docker-config/db/mariadb.cnf:/etc/mysql/conf.d/mariadb.cnf"
@@ -17,7 +22,7 @@ services:
     build: .
     image: webwork
     depends_on:
-      - db
+      - dbMB4
       - r
     volumes:
       - ".:/opt/webwork/webwork2"
@@ -34,12 +39,16 @@ services:
     ports:
       - "8080:80"
     environment:
-      DEV: 0
+      - DEV=0
+      - WEBWORK_DB_HOST=dbMB4
+      # - WEBWORK_DB_PORT=3306
+      # - WEBWORK_DB_NAME=webwork
+      - WEBWORK_DB_DSN=DBI:mysql:webwork:dbMB4:3306
   r:
     image: ubcctlt/rserve
     ports:
       - "6311:6311"
 
 volumes:
-  mysql:
+  mysqlMB4:
 

--- a/docker-config/db/mariadb.cnf
+++ b/docker-config/db/mariadb.cnf
@@ -1,0 +1,34 @@
+# MariaDB-specific config file.
+# Read by /etc/mysql/my.cnf
+
+[client]
+# Default is Latin1, if you need UTF-8 set this (also in server section)
+#default-character-set = utf8 
+
+# Based on:  https://salsa.debian.org/mariadb-team/mariadb-10.1/commit/e6ade2be57856736e8bc8039d71b35f9ffcde48e
+default-character-set = utf8mb4
+
+[mysql]
+# Based on:  https://salsa.debian.org/mariadb-team/mariadb-10.1/commit/e6ade2be57856736e8bc8039d71b35f9ffcde48e
+default-character-set = utf8mb4
+
+[mysqld]
+#
+# * Character sets
+# 
+# Default is Latin1, if you need UTF-8 set all this (also in client section)
+#
+#character-set-server  = utf8 
+#collation-server      = utf8_general_ci 
+#character_set_server   = utf8 
+#collation_server       = utf8_general_ci 
+
+# MySQL/MariaDB default is Latin1, but we want the full utf8 4-bit character set. 
+# See also client.cnf
+# Based on:  https://salsa.debian.org/mariadb-team/mariadb-10.1/commit/e6ade2be57856736e8bc8039d71b35f9ffcde48e
+character-set-server  = utf8mb4
+collation-server      = utf8mb4_general_ci
+character_set_server   = utf8mb4
+collation_server       = utf8mb4_general_ci
+init-connect='SET NAMES utf8mb4'
+

--- a/lib/WeBWorK/DB/Driver/SQL.pm
+++ b/lib/WeBWorK/DB/Driver/SQL.pm
@@ -69,7 +69,7 @@ sub new($$$) {
 		{
 			PrintError => 0,
 			RaiseError => 1,
-			mysql_enable_utf8 => 1,
+			mysql_enable_utf8mb4 => 1,
 		},
 	);
 	die $DBI::errstr unless defined $self->{handle};

--- a/lib/WeBWorK/DB/Record/LocationAddresses.pm
+++ b/lib/WeBWorK/DB/Record/LocationAddresses.pm
@@ -27,8 +27,8 @@ use warnings;
 
 BEGIN { 
 	__PACKAGE__->_fields(
-		location_id => { type=>"TINYBLOB NOT NULL", key=> 1 },
-		ip_mask     => { type=>"VARCHAR(255)", key=> 1 },
+		location_id => { type=>"TINYBLOB NOT NULL", key=> 1 }, # requires up to 256 bytes
+		ip_mask     => { type=>"VARCHAR(180)", key=> 1 }, # was VARCHAR(255), reduced to VARCHAR(180) for utf8mb4
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -30,9 +30,9 @@ BEGIN {
 	__PACKAGE__->_fields(
 
 	    answer_id         => {   type=>"INT AUTO_INCREMENT", key=>1},
-	    course_id         => { type=>"VARCHAR(100) NOT NULL", key=>1},
-	    user_id           => { type=>"VARCHAR(100) NOT NULL", key=>1},	
-	    set_id            => { type=>"VARCHAR(100) NOT NULL", key=>1},
+	    course_id         => { type=>"VARCHAR(80) NOT NULL", key=>1},
+	    user_id           => { type=>"VARCHAR(80) NOT NULL", key=>1},
+	    set_id            => { type=>"VARCHAR(80) NOT NULL", key=>1},
 	    problem_id        => { type=>"INT NOT NULL", key=>1},
 	    source_file       => { type=>"TEXT"},
 	    timestamp         => { type=>"INT" }, 

--- a/lib/WeBWorK/DB/Record/Setting.pm
+++ b/lib/WeBWorK/DB/Record/Setting.pm
@@ -30,7 +30,7 @@ use WeBWorK::Utils::DBUpgrade;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		name  => { type=>"VARCHAR(255) NOT NULL", key=>1 },
+		name  => { type=>"VARCHAR(240) NOT NULL", key=>1 },
 		value => { type=>"TEXT" },
 	);
 	__PACKAGE__->_initial_records(

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -516,7 +516,7 @@ sub getDBListings {
 #               $kw2";
 
 	my $pg_id_ref;
-	$dbh->do(qq{SET NAMES 'utf8';});
+	$dbh->do(qq{SET NAMES 'utf8mb4';});
 	if($haveTextInfo) {
 		my $query = "SELECT $selectwhat from `$tables{pgfile}` pgf, 
 			`$tables{dbsection}` dbsc, `$tables{dbchapter}` dbc, `$tables{dbsubject}` dbsj,


### PR DESCRIPTION
Modifed to use utf8mb4 in several places and to use a utf8mb4 database.

With these changes a Docker image using these settings worked.

Initially there was trouble with displaying problems via the library browser as the loading of the `OPL_global_statistics.sql` data initially failed.

Initial workaround:
```
vim conf/defaults.config
# Search for showLibraryLocalStats     set to 0
# Search for showLibraryGlobalStats    set to 0
```

Later, some small changes were manually made to `OPL_global_statistics.sql` (hacked by copying the file out of the the Docker container into /opt/webwork/webwork2, editing on the host PC, and then copying back into the proper location):
 
```
diff of OPL_global_statistics.sql
        utf8    => utf8mb4
        255     => 245
  ENGINE=InnoDB => ENGINE=MyISAM
=================================

10c10
< /*!40101 SET NAMES utf8mb4 */;
---
> /*!40101 SET NAMES utf8 */;
24c24
< /*!40101 SET character_set_client = utf8mb4 */;
---
> /*!40101 SET character_set_client = utf8 */;
26c26
<   `source_file` varchar(245) NOT NULL,
---
>   `source_file` varchar(255) NOT NULL,
31c31
< ) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4;
---
> ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

The main changes were that several database field lengths were reduced to keep the key size under the 1000 byte limit for MyISAM tables which becomes an issue when utf8mb4 is used, as it reserves 4 bytes per character.

Changes were also made to have the SQL connection use utf8mb4 instead of the 3-byte limited utf8.

During testing, I used a special version of the `docker-compose.yml` file include as `docker-compose.yml.specialUTF8MB4-db-storage` which used a different name for the database service and the database shared volume to avoid overwriting data I have in a non-utf8mb4 named volume of database data.

The current tree also seems to have a issue, as it now depends on XML::Simple (PR # 902), but the Docker file did not include that Perl module. Without fixing this issue the Docker container will not start. A temporary hack is to edit `bin/check_modules.pl` and `lib/WebworkClient.pm` and comment out 3 lines in total to temporarily remove the dependency temporarily. A longer term fix is to have this module pulled in when the image is built. That will be addressed in a later PR.

Hack:
```
diff --git a/bin/check_modules.pl b/bin/check_modules.pl
index c8f2fbdca..98fbc8fce 100755
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -113,7 +113,7 @@ my @modulesList = qw(
        UUID::Tiny
        XML::Parser
        XML::Parser::EasyTree
-       XML::Simple
+#      XML::Simple
        XML::Writer
        XMLRPC::Lite
        YAML


diff --git a/lib/WebworkClient.pm b/lib/WebworkClient.pm
index 38650d8b1..40a771e12 100755
--- a/lib/WebworkClient.pm
+++ b/lib/WebworkClient.pm
@@ -119,7 +119,7 @@ use HTML::Entities;
 use WeBWorK::PG::ImageGenerator;
 use IO::Socket::SSL;
 use Digest::SHA qw(sha1_base64);
-use XML::Simple qw(XMLout);
+#use XML::Simple qw(XMLout);
 
 use constant  TRANSPORT_METHOD => 'XMLRPC::Lite';
 use constant  REQUEST_CLASS    => 'WebworkXMLRPC';  # WebworkXMLRPC is used for soap also!!
@@ -621,7 +621,7 @@ sub formatRenderedProblem {
        my $encoded_source     = $self->encoded_source//'';
        my $sourceFilePath    = $self->{sourceFilePath}//'';
        my $warnings          = '';
-        my $answerhashXML     = XMLout($rh_answers, RootName => 'answerhashes');
+#        my $answerhashXML     = XMLout($rh_answers, RootName => 'answerhashes');
        
        #################################################
        # regular Perl warning messages generated with warn

```