### PR TITLE
RTL fixes for View and Edit in FileManager.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -467,7 +467,8 @@ sub View {
 	#
 	if (-T $file) { #check that it is a text file
 		my $data = readFile($file);
-		print CGI::pre(showHTML($data));
+		print CGI::div({dir=>"auto"},
+		    CGI::pre(showHTML($data)));
 	} elsif ($file =~ m/\.(gif|jpg|png)/i) {
 		print CGI::img({src=>$fileManagerURL, border=>0});
 	} else {
@@ -583,7 +584,7 @@ sub RefreshEdit {
 	print CGI::start_table({border=>0,cellspacing=>0,cellpadding=>2, width=>"95%", align=>"center"});
 	print CGI::Tr([
 		CGI::td({align=>"center",style=>"background-color:#CCCCCC"},CGI::b($name)),
-		CGI::td(CGI::textarea(-name=>"data",-default=>$data,-override=>1,-rows=>30,-columns=>80,
+		CGI::td(CGI::textarea(-name=>"data",-default=>$data,-override=>1,-rows=>30,-columns=>80,"dir"=>"auto",
 				-style=>"width:100%")), ## can't seem to get variable height to work
 		CGI::td({align=>"center", nowrap=>1},
 			CGI::input({%button,value=>$r->maketext("Cancel")}),"&nbsp;",


### PR DESCRIPTION
In `FileManager.pm` set the HTML `dir`(ection) attribute to "auto" in the `<textarea>` for "Edit" and in a (new) enveloping DIV around the `<pre>` for "View". 

Then in courses whose primary language use the RTL text direction, lines which start in LTR languages (most of the lines in PG files, the set definition files, etc) will be left justified and formatted nicely.

Without this, all lines would be right justified based on the main `dir="rtl"` which applies to the entire HTML page for courses whose languages use the RTL direction.