### PR TITLE
Add parent.postMessage for external communication

### DIFF
--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -52,6 +52,10 @@ json: $JSONanswerTemplate
 <p>
 jwt:$JWTanswerTemplate
 </p>
+
+<script type="text/javascript">window.addEventListener('load',()=>{
+parent.postMessage( {type: 'answerJWT',JWT:'$JWTanswerTemplate'}, "*",);
+})</script>
  
 </div>
 


### PR DESCRIPTION
@mgage, I haven't done integration testing if the $JWTanswerTemplate provides just the JWT, but at least the postMessage code itself does work.

For testing, here is the event listener that needs to be on the parent: window.addEventListener("message", (event)=>console.log(event), false);

Let me know once you have this on demo.webwork.rochester.edu and I can check that the JWT frontend passback works!