### PR TITLE
Remove or hide jwt:$JWTanswerTemplate

### DIFF
--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -45,10 +45,6 @@ $problemHeadText
 $answerTemplate
 </div>
 
-<p>
-jwt:$JWTanswerTemplate
-</p>
-
 <script type="text/javascript">window.addEventListener('load',()=>{
 parent.postMessage( {type: 'answerJWT',JWT:'$JWTanswerTemplate'}, "*",);
 })</script>


### PR DESCRIPTION
Since we have the parent.postMessage working, should we remove this or maybe keep it optional?
![image](https://user-images.githubusercontent.com/12994749/89210571-32e54e80-d575-11ea-9356-aeb7cb766251.png)
