### PR TITLE
Remove adapt_return_from_problemJWT

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -534,7 +534,7 @@ if ($format_name eq 'libretexts') {
 	$decode_problemJWT = pretty_print(jwt2hash(token=>$problemJWT,key=>'webwork'));
 	$decode_answerJWT = pretty_print(jwt2hash(token=>$answerJWT,key=>'webwork'));
 	$decode_sessionJWT = pretty_print(jwt2hash(token=>$sessionJWT,key=>'webwork'));
-	$adapt_call_return_problemJWT = post_to_ADAPT($problemJWT);
+	# $adapt_call_return_problemJWT = post_to_ADAPT($problemJWT);
 	$adapt_call_return_answerJWT = post_to_ADAPT($answerJWT);
 }
  

--- a/lib/WebworkClient/libretexts_format.pl
+++ b/lib/WebworkClient/libretexts_format.pl
@@ -77,7 +77,6 @@ $problemHeadText
 
 	
 <p>
-	adapt_return_from_problemJWT: |$adapt_call_return_problemJWT| <br/>
 	adapt_return_from_answerJWT:  |$adapt_call_return_answerJWT| <br/>
 
 


### PR DESCRIPTION
The adapt server doesn't do any processing for the problemJWT, so we shouldn't post to Adapt with it.